### PR TITLE
Add admin page to review pending withdrawals

### DIFF
--- a/packages/nextjs/app/admin/page.tsx
+++ b/packages/nextjs/app/admin/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { NextPage } from "next";
+import { useAccount } from "wagmi";
+import { StreamContributionItem } from "~~/components/StreamContributionItem";
+import { WithdrawalRequest, WithdrawalRequestItem } from "~~/components/WithdrawalRequest";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+import { useCohortWithdrawalRequests } from "~~/hooks/useCohortWithdrawalRequests";
+
+const Admin: NextPage = () => {
+  const { address: currentUserAddress } = useAccount();
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+
+  const { data: cohortWithdrawalRequestsData, isLoading: isLoadingCohortWithdrawalRequests } =
+    useCohortWithdrawalRequests();
+
+  const { data: isAdminData, isLoading: isCheckingAdmin } = useScaffoldReadContract({
+    contractName: "Cohort",
+    functionName: "isAdmin",
+    args: [currentUserAddress],
+  });
+
+  useEffect(() => {
+    if (isAdminData !== undefined) {
+      setIsAdmin(isAdminData);
+    }
+  }, [isAdminData]);
+
+  if (isCheckingAdmin || isAdmin === null) {
+    return <div className="text-center mt-8">Checking admin permissions...</div>;
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="text-center mt-8">
+        <h1 className="text-2xl font-bold">Access Denied</h1>
+        <p>You must be an admin to view this page.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 md:px-0">
+      <div id="builders" className="container mx-auto">
+        <section className="bg-base-300 rounded-lg p-8 mb-8">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-3xl md:text-4xl">Pending Withdrawals</h2>
+          </div>
+          <div className="mt-12">
+            <div className="hidden mb-2 lg:grid lg:grid-cols-4">
+              <div>
+                <p className="mt-0">Builder</p>
+              </div>
+              <div className="lg:col-span-2">
+                <p className="mt-0">Withdrawal Request</p>
+              </div>
+            </div>
+            <WithdrawalRequest>
+              {isLoadingCohortWithdrawalRequests ? (
+                <span className="loading loading-spinner loading-lg"></span>
+              ) : (
+                cohortWithdrawalRequestsData.map(withdrawalRequestData => (
+                  <WithdrawalRequestItem
+                    key={withdrawalRequestData.id}
+                    builder={withdrawalRequestData.builder}
+                    requestId={withdrawalRequestData.requestId}
+                    reason={withdrawalRequestData.reason}
+                    amount={withdrawalRequestData.amount}
+                    timestamp={withdrawalRequestData.timestamp}
+                    projectTitle={withdrawalRequestData.projectTitle}
+                    viewWork={withdrawalRequestData.withdrawals.length > 0}
+                  >
+                    <div className="px-6 rounded-lg bg-base-100 divide-y">
+                      {withdrawalRequestData.withdrawals.map(item => (
+                        <StreamContributionItem
+                          key={item.id}
+                          title={item.projectTitle}
+                          description={item.reason}
+                          date={new Date(item.timestamp * 1000).toLocaleDateString()}
+                          amount={item.amount}
+                        />
+                      ))}
+                    </div>
+                  </WithdrawalRequestItem>
+                ))
+              )}
+            </WithdrawalRequest>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Admin;

--- a/packages/nextjs/components/WithdrawalRequest.tsx
+++ b/packages/nextjs/components/WithdrawalRequest.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { StreamContributionItem } from "./StreamContributionItem";
+import toast from "react-hot-toast";
+import { BuilderAddress, BuilderAddressProps } from "~~/components/BuilderAddress";
+import { useScaffoldWriteContract } from "~~/hooks/scaffold-eth";
+
+interface WithdrawalRequestItemProps {
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+  builder: BuilderAddressProps;
+  requestId: bigint;
+  reason: string;
+  amount: number;
+  timestamp: number;
+  projectTitle: string;
+  viewWork: boolean;
+}
+
+export function WithdrawalRequest({ children }: { children: React.ReactNode }) {
+  return <div className="space-y-8">{children}</div>;
+}
+
+export function WithdrawalRequestItem({
+  defaultOpen = false,
+  children,
+  builder,
+  requestId,
+  reason,
+  amount,
+  timestamp,
+  projectTitle,
+  viewWork,
+}: WithdrawalRequestItemProps) {
+  const [isOpen, setIsOpen] = useState(defaultOpen);
+  const [isApproving, setIsApproving] = useState(false);
+  const [isRejecting, setIsRejecting] = useState(false);
+  const [approved, setApproved] = useState(false);
+  const [rejected, setRejected] = useState(false);
+
+  const { writeContractAsync: cohortContract } = useScaffoldWriteContract({
+    contractName: "Cohort",
+  });
+
+  const handleApprove = async () => {
+    try {
+      setIsApproving(true);
+      await cohortContract({
+        functionName: "approveWithdraw",
+        args: [builder.address, requestId],
+      });
+      toast.success("Withdrawal approved successfully!");
+      setApproved(true);
+    } catch (error) {
+      console.error("Failed to approve withdrawal:", error);
+      toast.error("Failed to approve withdrawal. Please try again.");
+    } finally {
+      setIsApproving(false);
+    }
+  };
+
+  const handleReject = async () => {
+    try {
+      setIsRejecting(true);
+      await cohortContract({
+        functionName: "rejectWithdraw",
+        args: [builder.address, requestId],
+      });
+      toast.success("Withdrawal rejected successfully!");
+      setRejected(true);
+    } catch (error) {
+      console.error("Failed to reject withdrawal:", error);
+      toast.error("Failed to reject withdrawal. Please try again.");
+    } finally {
+      setIsRejecting(false);
+    }
+  };
+
+  return (
+    <div className="overflow-hidden">
+      <div className="grid grid-cols-1 gap-2 lg:grid-cols-4">
+        <div>
+          <BuilderAddress address={builder.address} x={builder.x} github={builder.github} />
+        </div>
+        <div className="lg:col-span-3">
+          <div className="mt-2 flex items-center gap-2 md:gap-6">
+            <StreamContributionItem
+              title={projectTitle}
+              description={reason}
+              date={new Date(timestamp * 1000).toLocaleDateString()}
+              amount={amount}
+            />
+            {approved && <div>Withdrawal approved!</div>}
+            {rejected && <div>Withdrawal rejected!</div>}
+            {!approved && !rejected && (
+              <>
+                <button
+                  className={`btn btn-success btn-xs !min-h-8 !h-8 lg:btn-md lg:!min-h-10 lg:!h-10 ${isApproving ? "loading" : ""}`}
+                  onClick={handleApprove}
+                  disabled={isApproving}
+                >
+                  Approve
+                </button>
+                <button
+                  className={`btn btn-error btn-xs !min-h-8 !h-8 lg:btn-md lg:!min-h-10 lg:!h-10 ${isRejecting ? "loading" : ""}`}
+                  onClick={handleReject}
+                  disabled={isRejecting}
+                >
+                  Reject
+                </button>
+              </>
+            )}
+            <button
+              onClick={() => setIsOpen(!isOpen)}
+              className="btn btn-primary btn-xs !min-h-8 !h-8 lg:btn-md lg:!min-h-10 lg:!h-10"
+              disabled={!viewWork}
+            >
+              {isOpen ? "Hide Previous Work" : "View Previous Work"}
+            </button>
+          </div>
+        </div>
+      </div>
+      {isOpen && <div className="mt-8">{children}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
![localhost_3000_admin (24)](https://github.com/user-attachments/assets/f00802d3-411d-4b75-a1ef-6bf1d906a2f1)

Available at /admin (not added to the menu header, we can add this by checking the connectedAddress if we want).

The design can be improved.

If the user trying to access the page is not an admin from the contract, a message will appear on the page.

There are improvements to the types. We can reuse some of them; we can do it in a later PR.